### PR TITLE
Allow configuring ground recording directory

### DIFF
--- a/VideoCore/src/main/java/constantin/video/core/player/VideoSettings.java
+++ b/VideoCore/src/main/java/constantin/video/core/player/VideoSettings.java
@@ -98,14 +98,22 @@ public class VideoSettings {
         }
     }
 
+    private static volatile String groundRecordingDirectory = null;
+
+    /** When set, ground recordings are saved under this directory instead of the default. */
+    public static void setGroundRecordingDirectory(final String directory) {
+        groundRecordingDirectory = directory;
+    }
+
     public static String getDirectoryToSaveDataTo(){
-        final String ret= Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MOVIES)+"/FPV_VR/";
+        final String ret = groundRecordingDirectory != null && !groundRecordingDirectory.isEmpty()
+                ? groundRecordingDirectory
+                : Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MOVIES) + "/FPV_VR/";
         File dir = new File(ret);
         if (!dir.exists()) {
-            final boolean mkdirs = dir.mkdirs();
-            //System.out.println("mkdirs res"+mkdirs);
+            dir.mkdirs();
         }
-        return ret;
+        return ret.endsWith("/") ? ret : ret + "/";
     }
 
     // Adds a .fpv file (created via the ndk file api) to the ContentResolver such that it is


### PR DESCRIPTION
This change adds an optional API for configuring the directory used for ground recordings.

Applications may call VideoSettings.setGroundRecordingDirectory(path) before creating a VideoPlayer. If no directory is configured, the existing default (Movies/FPV_VR/) is used, so existing behavior is unchanged.

The configured path is normalized to ensure it ends with a trailing /, matching the existing directory handling.